### PR TITLE
Kintamųjų pavadinimą nepradedame didžiąja raide

### DIFF
--- a/script.js
+++ b/script.js
@@ -14,9 +14,9 @@ let y2;
 y2 = prompt("Įveskite B taško Y koordinates");
 y2 = + y2;
 
-let AB = atkarposIlgis(x1, y1, x2, y2);
+let atstumas = atkarposIlgis(x1, y1, x2, y2);
 console.log(+ AB);
 
-function atkarposIlgis(Ax, Ay, Bx, By){
-    return Math.sqrt((Bx - Ax) * (Bx - Ax) + (By - Ay) * (By - Ay));
+function atkarposIlgis(x1, y1, x2, y2){
+    return Math.sqrt((x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1));
 }


### PR DESCRIPTION
Pakeičiau kintamųjų pavadinimus, kadangi JavaScripte pagal stilistiką kintamieji visada yra pradedami mažąja raide, o sekantis žodis tame pavadinime prasideda didžiąja. Taip vadinamu camel case: https://en.wikipedia.org/wiki/Camel_case